### PR TITLE
improve error message if patition key is not provided for a new conta…

### DIFF
--- a/lib/src/cosmos_db_containers.dart
+++ b/lib/src/cosmos_db_containers.dart
@@ -104,7 +104,8 @@ class CosmosDbContainers {
       return await open(name);
     } on NotFoundException {
       if(partitionKey == null){
-        throw "container '$name' not found - can not create with a null partion key";
+        throw ApplicationException(
+          "container '$name' not found - can not create with a null partion key");
       }
       return await create(
         name,

--- a/lib/src/cosmos_db_containers.dart
+++ b/lib/src/cosmos_db_containers.dart
@@ -103,9 +103,12 @@ class CosmosDbContainers {
     try {
       return await open(name);
     } on NotFoundException {
+      if(partitionKey == null){
+        throw "container '$name' not found - can not create with a null partion key";
+      }
       return await create(
         name,
-        partitionKey: partitionKey!,
+        partitionKey: partitionKey,
         indexingPolicy: indexingPolicy,
         geospatialConfig: geospatialConfig,
         throughput: throughput,


### PR DESCRIPTION
I'm new to cosmos db, so when I got a null check error it wasn't obvious what was going on, so this would make it clear that the partition key is needed if the container does not yet exist.

Wasn't able to get the tests running, but I couldn't find any that covered this case.  Would consider adding one if there was a mocking framework in place.
