### PR TITLE
add none constructor to throughput for serverless config

### DIFF
--- a/lib/src/cosmos_db_throughput.dart
+++ b/lib/src/cosmos_db_throughput.dart
@@ -6,12 +6,16 @@ import 'cosmos_db_exceptions.dart';
 
 /// Class representing a CosmosDB throughput.
 class CosmosDbThroughput {
+  
   /// Creates a new manual [throughput] RUs. Must be a multiple of 100. Minimum allowed
   /// is 400 RUs.
   CosmosDbThroughput(int throughput)
-      : header = {
-          HttpHeader.msOfferThroughput: throughput.toString(),
-        } {
+      : header = createHeader(throughput);
+
+  /// Used for servles instances where throughput can't be set
+  CosmosDbThroughput.none(): header = {};
+
+  static Map<String, String> createHeader(int throughput) {
     if (throughput < _min) {
       throw ApplicationException(
           'Invalid throughput: minimum value is $_min RUs.');
@@ -20,6 +24,7 @@ class CosmosDbThroughput {
       throw ApplicationException(
           'Invalid throughput: value must be a multiple of 100 RUs.');
     }
+    return {HttpHeader.msOfferThroughput: throughput.toString(),};
   }
 
   /// Creates a new auto-scale throughput for [maxThroughput] RUs. Must be a multiple
@@ -47,4 +52,5 @@ class CosmosDbThroughput {
 
   static final _min = 400;
   static final _minAutoScale = 1000;
+  
 }


### PR DESCRIPTION
added CosmosDbThoughput.none constructor, this sets an empty header.  This allows serverless DBs to create containers.  It may also allow other use cases.  As mentioned in the other PR I haven't been able to get the tests working, but I can't see how this would break anything. (famous last words)